### PR TITLE
Removed font width after frame hook caching

### DIFF
--- a/doom-modeline-core.el
+++ b/doom-modeline-core.el
@@ -802,7 +802,6 @@ then this function does nothing."
   (setq doom-modeline--font-width-cache nil)
   (doom-modeline--font-width))
 (add-hook 'window-setup-hook #'doom-modeline-refresh-font-width-cache)
-(add-hook 'after-make-frame-functions #'doom-modeline-refresh-font-width-cache)
 (add-hook 'after-setting-font-hook #'doom-modeline-refresh-font-width-cache)
 
 (defun doom-modeline-def-modeline (name lhs &optional rhs)


### PR DESCRIPTION
This caused a regression in which multiple created frame with the emacs daemon would have the wrong modeline width except for the first created